### PR TITLE
Check for global `document` rather than `exports` with INTO HTML

### DIFF
--- a/src/830into.js
+++ b/src/830into.js
@@ -71,7 +71,7 @@ alasql.into.SQL = function (filename, opts, data, columns, cb) {
 
 alasql.into.HTML = function (selector, opts, data, columns, cb) {
 	var res = 1;
-	if (typeof exports !== 'object') {
+	if (typeof document !== 'object') {
 		var opt = {headers: true};
 		alasql.utils.extend(opt, opts);
 


### PR DESCRIPTION
This allows for one to set a `global.document = document` in Node via the likes of JSDom to query HTML one has parsed in Node (on the server side).

A better approach might be allowing the user to supply the document object as an option, but as it seems you don't really accept options in the constructor, I thought this might be as easy.

One other item this PR doesn't handle is that it is possible that `SELECT * FROM TXT('#one')` could be supported in Node too.