### PR TITLE
Fix: AST to string causes double aliases

### DIFF
--- a/src/50expression.js
+++ b/src/50expression.js
@@ -159,12 +159,11 @@ yy.JavaScript.prototype.execute = function (databaseid, params, cb) {
 yy.Literal = function (params) {
 	return yy.extend(this, params);
 };
-yy.Literal.prototype.toString = function (dontas) {
+yy.Literal.prototype.toString = function () {
 	var s = this.value;
 	if (this.value1) {
 		s = this.value1 + '.' + s;
 	}
-	if (this.alias && !dontas) s += ' AS ' + this.alias;
 	//	else s = tableid+'.'+s;
 	return s;
 };
@@ -854,7 +853,7 @@ yy.UniOp.prototype.toJS = function (context, tableid, defcols) {
 yy.Column = function (params) {
 	return yy.extend(this, params);
 };
-yy.Column.prototype.toString = function (dontas) {
+yy.Column.prototype.toString = function () {
 	var s;
 	if (this.columnid == +this.columnid) {
 		// jshint ignore:line
@@ -872,7 +871,6 @@ yy.Column.prototype.toString = function (dontas) {
 			s = this.databaseid + '.' + s;
 		}
 	}
-	if (this.alias && !dontas) s += ' AS ' + this.alias;
 	return s;
 };
 
@@ -997,9 +995,6 @@ yy.AggrValue.prototype.toString = function (dontas) {
 	if (this.over) {
 		s += ' ' + this.over.toString();
 	}
-	//	console.log(this.over);
-	if (this.alias && !dontas) s += ' AS ' + this.alias;
-	//	if(this.alias) s += ' AS '+this.alias;
 	return s;
 };
 

--- a/src/50expression.js
+++ b/src/50expression.js
@@ -64,8 +64,8 @@ yy.Expression = function (params) {
 	@this ExpressionStatement
 	@return {string}
 */
-yy.Expression.prototype.toString = function (dontas) {
-	var s = this.expression.toString(dontas);
+yy.Expression.prototype.toString = function () {
+	var s = this.expression.toString();
 	if (this.order) {
 		s += ' ' + this.order.toString();
 	}
@@ -974,7 +974,7 @@ yy.Column.prototype.toJS = function (context, tableid, defcols) {
 yy.AggrValue = function (params) {
 	return yy.extend(this, params);
 };
-yy.AggrValue.prototype.toString = function (dontas) {
+yy.AggrValue.prototype.toString = function () {
 	var s = '';
 	if (this.aggregatorid === 'REDUCE') {
 		s += this.funcid.replace(re_invalidFnNameChars, '') + '(';

--- a/src/55functions.js
+++ b/src/55functions.js
@@ -11,7 +11,7 @@ yy.FuncValue = function (params) {
 };
 
 var re_invalidFnNameChars = /[^0-9A-Z_$]+/i;
-yy.FuncValue.prototype.toString = function (dontas) {
+yy.FuncValue.prototype.toString = function () {
 	var s = '';
 
 	if (alasql.fn[this.funcid]) s += this.funcid;

--- a/src/55functions.js
+++ b/src/55functions.js
@@ -30,9 +30,6 @@ yy.FuncValue.prototype.toString = function (dontas) {
 		}
 		s += ')';
 	}
-
-	if (this.as && !dontas) s += ' AS ' + this.as.toString();
-	//	if(this.alias) s += ' AS '+this.alias;
 	return s;
 };
 
@@ -114,8 +111,6 @@ yy.FuncValue.prototype.toJS = function (context, tableid, defcols) {
 		s += ')';
 	}
 	//console.log('userfn:',s,this);
-
-	//	if(this.alias) s += ' AS '+this.alias;
 	return s;
 };
 

--- a/test/test815.js
+++ b/test/test815.js
@@ -6,7 +6,7 @@ if (typeof exports === 'object') {
 var test = '815'; // insert test file number
 
 describe('Test ' + test + ' - ast.toString() causes repeated aliases', function () {
-	it('TODO', function () {
+	it('Should parse query to AST, then stringify back to the same query', function () {
 		var query = 'SELECT genre, title AS t, LENGTH(title) AS length FROM tbl AS t1';
 		var ast = alasql.parse(query);
 		assert.strictEqual(ast.toString(), query)

--- a/test/test815.js
+++ b/test/test815.js
@@ -1,0 +1,14 @@
+if (typeof exports === 'object') {
+	var assert = require('assert');
+	var alasql = require('..');
+}
+
+var test = '815'; // insert test file number
+
+describe('Test ' + test + ' - ast.toString() causes repeated aliases', function () {
+	it('TODO', function () {
+		var query = 'SELECT genre, title AS t, LENGTH(title) AS length FROM tbl AS t1';
+		var ast = alasql.parse(query);
+		assert.strictEqual(ast.toString(), query)
+	});
+});

--- a/test/test816.js
+++ b/test/test816.js
@@ -3,7 +3,7 @@ if (typeof exports === 'object') {
 	var alasql = require('..');
 }
 
-var test = '815'; // insert test file number
+var test = '816'; // insert test file number
 
 describe('Test ' + test + ' - ast.toString() causes repeated aliases', function () {
 	it('Should parse query to AST, then stringify back to the same query', function () {


### PR DESCRIPTION
Fixes https://github.com/AlaSQL/alasql/issues/1426

During `ast.toString()`, the function alias is being set in two places: At the `yy.FuncValue` level and the `yy.Select` level. This is causing double aliases to be generated for functions when stringifying the AST, e.g. `SELECT LENGTH(col) AS length AS length`. 

This problem would have existed on other tokens such as `yy.Literal`s too, but they seem to use an outdated(?) `this.alias` which always returns `undefined`. Updating the `yy.Literal` code to use `this.as` causes the problem to appear for literals too, e.g. `SELECT col AS c AS c`.

My solution is to just remove any alias handling-code from tokens which could represent columns, and let `yy.Select` handle those aliases as it currently does. 
