### PR TITLE
Fix newDate() and Now() reverted back the date format

### DIFF
--- a/src/61date.js
+++ b/src/61date.js
@@ -51,9 +51,9 @@ stdfn.NOW = function () {
 	var d = new Date();
 	var s =
 		d.getFullYear() +
-		'-' +
+		'.' +
 		('0' + (d.getMonth() + 1)).substr(-2) +
-		'-' +
+		'.' +
 		('0' + d.getDate()).substr(-2);
 	s +=
 		' ' +
@@ -166,12 +166,24 @@ alasql.stdfn.DATE_SUB = alasql.stdfn.SUBDATE = function (d, interval) {
 	return new Date(nd);
 };
 
-var dateRegexp = /^\d{4}\.\d{2}\.\d{2} \d{2}:\d{2}:\d{2}/;
+var dateRegexp = /^(?<year>\d{4})[-\.](?<month>\d{1,2})[-\.](?<day>\d{1,2})( (?<hours>\d{2}):(?<minutes>\d{2})(:(?<seconds>\d{2})(\.(?<milliseconds>)\d{3})?)?)?/;
 function newDate(d) {
-	if (typeof d === 'string') {
-		if (dateRegexp.test(d)) {
-			d = d.replace('.', '-').replace('.', '-');
+	let date = new Date(d);
+
+	if (isNaN(date)) {
+		if (typeof d === 'string') {
+			const match = d.match(dateRegexp);
+			if (match) {
+				const { year, month, day, hours, minutes, seconds, milliseconds } = match.groups;
+				const dateArrguments = [year, month - 1, day];
+				if (hours) {
+					dateArrguments.push(hours, minutes, seconds || 0, milliseconds || 0);
+				}
+
+				date = new Date(...dateArrguments);
+			}
 		}
 	}
-	return new Date(d);
+
+	return date;
 }

--- a/test/test845.js
+++ b/test/test845.js
@@ -12,8 +12,8 @@ var test = '845'; // insert test file number
 describe('Test ' + test + ' - use NOW() function', function () {
 	it('1. NOW()', function () {
 		var res = alasql('SELECT NOW() AS now');
-		//2022-02-25 19:21:27.839
-		assert(/\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3}/.test(res[0].now));
+		//2022.02.25 19:21:27.839
+		assert(/\d{4}.\d{2}.\d{2} \d{2}:\d{2}:\d{2}.\d{3}/.test(res[0].now));
 	});
 
 	it('2. CONVERT with NOW() as an argument', function () {


### PR DESCRIPTION
newDate() for Safari (et. al.)
Supported formats:
"2022.01.10 04:10",
"2022.01.10 04:10:11",
"2022.01.10 04:10:11.123",
"2022-01-10 04:10",
"2022-01-10 04:10:11",
"2022-01-10 04:10:11.123",
"2022.1.10",
"2022-1-1"
...

Fix for NOW() in Firefox: reverted back the date format: 2022-11-01 -> 2022.11.01





