### PR TITLE
Add content type response header

### DIFF
--- a/test/browserTestRunner.js
+++ b/test/browserTestRunner.js
@@ -6,7 +6,13 @@
 	const {exec} = require('child_process');
 
 	const port = argv[2] || 8888;
-
+	/** @type {Object<string, string>} */
+	const types = {
+		'js': 'text/javascript',
+		'html': 'text/html',
+		'css': 'text/css',
+		'json': 'application/json',
+	}
 	// Making HTML for the test
 	const template = fs.readFileSync(__dirname + '/browserTestRunner.tmlp.html', 'utf8');
 
@@ -67,7 +73,12 @@
 			return;
 		}
 
-		response.writeHead(200);
+		const type = types[path.extname(filename).slice(1)];
+
+		response.writeHead(200, 'OK', {
+			'content-type': type || 'application/octet-stream'
+		});
+
 		fs.createReadStream(filename).pipe(response);
 	})
 	.listen(port);

--- a/test/browserTestRunner.js
+++ b/test/browserTestRunner.js
@@ -6,13 +6,14 @@
 	const {exec} = require('child_process');
 
 	const port = argv[2] || 8888;
-	/** @type {Object<string, string>} */
+
 	const types = {
 		'js': 'text/javascript',
 		'html': 'text/html',
 		'css': 'text/css',
 		'json': 'application/json',
 	}
+
 	// Making HTML for the test
 	const template = fs.readFileSync(__dirname + '/browserTestRunner.tmlp.html', 'utf8');
 

--- a/test/test208.js
+++ b/test/test208.js
@@ -15,7 +15,7 @@ if (typeof exports != 'object') {
 				var res = alasql('SELECT VALUE 200');
 				assert(res == 200);
 				alasql.worker();
-				//            console.log(alasql.webworker)
+				// console.log(alasql.webworker)
 				alasql('SELECT VALUE 300', [], function (res) {
 					assert(res == 300);
 					alasql.worker(false);


### PR DESCRIPTION
Web worker test are failing in chrome if it's not served with the correct content type.