### PR TITLE
preload assets before running test and mock them

### DIFF
--- a/src/87source.js
+++ b/src/87source.js
@@ -19,7 +19,7 @@ yy.Source.prototype.toString = function () {
 yy.Source.prototype.execute = function (databaseid, params, cb) {
 	//	console.log(this.url);
 	var res;
-	loadFile(
+	alasql.utils.loadFile(
 		this.url,
 		!!cb,
 		function (data) {

--- a/src/88require.js
+++ b/src/88require.js
@@ -40,7 +40,7 @@ yy.Require.prototype.execute = function (databaseid, params, cb) {
 	//	console.log(this.paths);
 	if (this.paths && this.paths.length > 0) {
 		this.paths.forEach(function (path) {
-			loadFile(path.value, !!cb, function (data) {
+			alasql.utils.loadFile(path.value, !!cb, function (data) {
 				res++;
 				//				console.log(res,self.paths.length);
 				//				console.log(data);
@@ -56,16 +56,20 @@ yy.Require.prototype.execute = function (databaseid, params, cb) {
 		this.plugins.forEach(function (plugin) {
 			// If plugin is not loaded already
 			if (!alasql.plugins[plugin]) {
-				loadFile(alasql.path + '/alasql-' + plugin.toLowerCase() + '.js', !!cb, function (data) {
-					// Execute all plugins at the same time
-					res++;
-					ss += data;
-					if (res < self.plugins.length) return;
-					// console.log(346346, ss);
-					new Function('params,alasql', ss)(params, alasql);
-					alasql.plugins[plugin] = true; // Plugin is loaded
-					if (cb) res = cb(res);
-				});
+				alasql.utils.loadFile(
+					alasql.path + '/alasql-' + plugin.toLowerCase() + '.js',
+					!!cb,
+					function (data) {
+						// Execute all plugins at the same time
+						res++;
+						ss += data;
+						if (res < self.plugins.length) return;
+						// console.log(346346, ss);
+						new Function('params,alasql', ss)(params, alasql);
+						alasql.plugins[plugin] = true; // Plugin is loaded
+						if (cb) res = cb(res);
+					}
+				);
 			}
 		});
 	} else {

--- a/test/test000.js
+++ b/test/test000.js
@@ -1,7 +1,47 @@
+const assets = [
+	'dist/alasql-echo.js',
+	'dist/alasql-prolog.js',
+	'test127.sql',
+	'test128.sql',
+	'test198-1.sql',
+	'test198-2.sql',
+	'test203myfn.js1',
+	'test203myfn2.js1',
+	'test305a.gexf',
+	'test306.xml',
+	'test306a.xml',
+];
+
+const fixtures = {};
+
 if (typeof exports === 'object') {
-	var assert = require('assert');
+	var fs = require('fs');
+	var path = require('path');
 	var alasql = require('..');
+	globalThis.fixturesAssets = {};
+	assets.forEach((asset) => {
+		fixtures[asset] = fs.readFileSync(path.join(__dirname, asset), 'utf8');
+	});
+} else {
+	before(async () => {
+		return Promise.all(
+			assets.map((asset) =>
+				fetch(asset)
+					.then((res) => res.text())
+					.then((text) => {
+						fixtures[asset] = text;
+					})
+			)
+		);
+	});
 }
+
+const load = alasql.utils.loadFile;
+alasql.utils.loadFile = function (path, asy, cb, err) {
+	if (asy) return load(...arguments);
+	const file = assets.find(x => path.split('/').pop() === x.split('/').pop());
+	return cb(fixtures[file])
+};
 
 describe('Test 000 - multiple statements', function () {
 	const test = '000'; // insert test file number


### PR DESCRIPTION
After sync loading of files in https://github.com/AlaSQL/alasql/commit/5c7375b6d9e427dbdc063e8a1296b09d6881d74e got removed then some test started to fail. 

There was either the option of changing the test to also become async and instead use `alasql.promise` or load the resources beforehand and then create a own sync loader and override the `alasql.utils.loadFile` with a own sync mock loader.

i opt'ed for the 2nd solution as some test are specifically to test sync functionality.