### PR TITLE
fix: GROUP BY with CASE x IS NULL

### DIFF
--- a/src/50expression.js
+++ b/src/50expression.js
@@ -396,21 +396,9 @@
 					this.right instanceof yy.NullValue ||
 					(this.right.op === 'NOT' && this.right.right instanceof yy.NullValue)
 				) {
-					s = `(
-					(${leftOperand}==null)   // Cant be ===
-					===
-					(${rightOperand}==null)  // Cant be ===
-				)`;
+					s = `((${leftOperand} == null) === (${rightOperand} == null))`; // == null cant be ===
 				} else {
-					s = `(
-					(${leftOperand} == ${rightOperand})
-					||
-					(
-						${leftOperand}  < 0
-						&&
-						true == ${rightOperand}
-					)
-				)`;
+					s = `((${leftOperand} == ${rightOperand}) || (${leftOperand}  < 0 && true == ${rightOperand}))`;
 				}
 			}
 

--- a/test/test819.js
+++ b/test/test819.js
@@ -1,0 +1,23 @@
+if (typeof exports === 'object') {
+	var assert = require('assert');
+	var alasql = require('../dist/alasql');
+}
+
+describe('Test 819 GROUP BY with CASE', function () {
+	it('1. Use GROUP BY with CASE with IS NULL', function (done) {
+		var data = [
+			{id: 'id1', alternativeId: undefined},
+			{id: 'id2', alternativeId: undefined},
+			{id: 'id2', alternativeId: undefined},
+			{id: undefined, alternativeId: 'id2'},
+			{id: undefined, alternativeId: 'id3'},
+		];
+
+		var res = alasql(
+			'SELECT COUNT(*) FROM ? GROUP BY CASE WHEN id IS NULL THEN alternativeId ELSE id END',
+			[data]
+		);
+		assert.deepEqual(res, [{'COUNT(*)': 1}, {'COUNT(*)': 3}, {'COUNT(*)': 1}]);
+		done();
+	});
+});


### PR DESCRIPTION
For case:

`SELECT COUNT(*) FROM ? GROUP BY CASE WHEN id IS NULL THEN alternativeId ELSE id END

>>> SyntaxError: Unexpected token ']'
`
Сause: in the file '423groupby.js' there are many places similar to col2.split('\t'), but in toJS() we use template literals with a lot of \t.
	


