### PR TITLE
Fix (#1616): INSERT INTO with a SELECT * FROM and a subquery throws exception

### DIFF
--- a/src/70insert.js
+++ b/src/70insert.js
@@ -230,6 +230,9 @@ yy.Insert.prototype.compile = function (databaseid) {
 		// INSERT INTO table SELECT
 	} else if (this.select) {
 		this.select.modifier = 'RECORDSET';
+		if (this.queries) {
+			this.select.queries = this.queries;
+		}
 		var selectfn = this.select.compile(databaseid);
 		if (db.engineid && alasql.engines[db.engineid].intoTable) {
 			var statement = function (params, cb) {


### PR DESCRIPTION
**What is the PR `for?**

- It is an attempt to fix the issue [#1616](https://github.com/AlaSQL/alasql/issues/1616)

**Description**  : 

 - It seems that the statement `alasql.exec('SELECT * FROM t2 WHERE val = (SELECT val FROM t3 WHERE id= 2)')` work fine without throwing any errors.  And the ast object has statement property which contain sql statement itself at index 0. this property contains `queries object`. Something like this :
```js
SELECT * FROM t2 WHERE val = SELECT val FROM t3 WHERE id = 2
statements: (1) [yy.Select]
      0: SELECT * FROM t2 WHERE val = SELECT val FROM t3 WHERE id = 2
            columns: (1) [Column]
            from:  (1) [Table]
            queries: (1) [yy.Select]    // <-   This property is present here
            where:  val = SELECT val FROM t3 WHERE id = 2
```
-  But for the statement `alasql.exec('INSERT INTO t SELECT * FROM t2 WHERE val = (SELECT val FROM t3 WHERE id= 2)')` `queries` property is present in `insert object` which also contain nested `select Object` where `queries` property is missing For example 
```js
INSERT INTO t SELECT * FROM t2 WHERE val = SELECT val FROM t3 WH
statements:(1) [yy.Insert]
	0: INSERT INTO t SELECT * FROM t2 WHERE val = SELECT val FROM t3 WH
	     into: t
	    queries: (1) [yy.Select]  // present here
	     select: SELECT * FROM t2 WHERE val = SELECT val FROM t3 WHERE id = 2
		columns:(1) [Column]
		from: (1) [Table]  // missing here
		where: val = SELECT val FROM t3 WHERE id = 2
```
- **To avoid the exception the code changes adds the missing `queries` property in `nested select` object**

