### PR TITLE
fix #1415: UNION not returning correct result

### DIFF
--- a/src/38query.js
+++ b/src/38query.js
@@ -242,10 +242,17 @@ function queryfn3(query) {
 			ilen = nd.data.length;
 			for (var i = 0; i < ilen; i++) {
 				r = {};
-				jlen = Math.min(query.columns.length, nd.columns.length);
-				for (var j = 0; j < jlen; j++) {
-					r[query.columns[j].columnid] = nd.data[i][nd.columns[j].columnid];
-				}
+				if (query.columns.length) {
+					jlen = Math.min(query.columns.length, nd.columns.length);
+					for (var j = 0; j < jlen; j++) {
+						r[query.columns[j].columnid] = nd.data[i][nd.columns[j].columnid];
+					}
+				} else {
+					jlen = nd.columns.length;
+					for (var j = 0; j < jlen; j++) {
+						r[nd.columns[j].columnid] = nd.data[i][nd.columns[j].columnid];
+					}
+				}			
 				ud.push(r);
 			}
 		}

--- a/src/38query.js
+++ b/src/38query.js
@@ -252,7 +252,7 @@ function queryfn3(query) {
 					for (var j = 0; j < jlen; j++) {
 						r[nd.columns[j].columnid] = nd.data[i][nd.columns[j].columnid];
 					}
-				}			
+				}
 				ud.push(r);
 			}
 		}

--- a/test/test1415.js
+++ b/test/test1415.js
@@ -1,0 +1,27 @@
+if (typeof exports === 'object') {
+	var assert = require('assert');
+	var alasql = require('..');
+} else {
+	__dirname = '.';
+}
+
+describe('Test 1415 - UNION Expression with empty query columns bug', function () {
+	it('1. should not insert empty objects in results when using UNION Expression', function (done) {
+        var data1 = [
+            {a: 'abc'},
+            {a: 'xyz'}
+        ];
+        var data2 = [
+            {a: '123'},
+            {a: '987'}
+        ];
+
+		var res = alasql("SELECT * FROM :a UNION SELECT * FROM :b", {a: data1, b: data2});
+		assert.deepEqual(res, [{a: '123'}, {a: '987'}, { a: 'abc'}, {a: 'xyz'}]);
+
+        var res = alasql("SELECT * FROM @[{x: true}, {x: 3}] UNION SELECT * FROM @[{x: false}, {x: 9}]");
+		assert.deepEqual(res, [{x: false}, {x: 9}, {x: true}, {x: 3}]);
+
+		done();
+	});
+});


### PR DESCRIPTION
**What is the PR `for?**
- This is an attempt to fix the issue [#1415](https://github.com/AlaSQL/alasql/issues/1415).
- It seems that empty objects where due to `query.columns.length = 0`. That is why `res` and `res2` had empty objects like this `{}`. May be the solution should make sure that `query.columns.length !=0`.  
- The solution in this pr might be a bad approach to resolve the issue. But if there are any feedback or issues related to my current solution than i could try to work on different approach too.🙂

**Examples :**
```js
var data1=[{a:'abc'},{a:'xyz'}];
var data2=[{a:'123'},{a:'987'}];
var res = alasql("select * from :a union select * from :b",{a:data1,b:data2});

console.log(res); // [ { a: '123' }, { a: '987' }, { a: 'abc' }, { a: 'xyz' } ]

var res2 = alasql("select * from @[{x:true}, {x:3}] UNION select * from @[{x:false}, {x:9}]");

console.log(res2); // [ { x: false }, { x: 9 }, { x: true }, { x: 3 } ]

alasql("CREATE TABLE one (a string)");
alasql("CREATE TABLE Two (a string)");
alasql("INSERT INTO one VALUES ('abc'),('xyz')");
alasql("INSERT INTO Two VALUES ('123'),('987')");

var res3 = alasql("SELECT * FROM one union SELECT * FROM Two");

console.log(res3) // [ { a: 'abc' }, { a: 'xyz' }, { a: '123' }, { a: '987' } ]
```