### PR TITLE
fix: .d.ts exports

### DIFF
--- a/types/alasql.d.ts
+++ b/types/alasql.d.ts
@@ -1,8 +1,9 @@
 // Project: https://github.com/alasql/alasql
 
-import * as xlsx from 'xlsx';
+declare module "alasql" {
 
-declare namespace alaSQLSpace {
+	import * as xlsx from 'xlsx';
+
 	interface AlaSQLCallback {
 		(data?: any, err?: Error): void;
 	}
@@ -83,7 +84,7 @@ declare namespace alaSQLSpace {
 		yy: {};
 		setXLSX(xlsxlib: typeof xlsx): void;
 	}
+	const alasql: AlaSQL;
+	export = alasql;
 }
 
-declare let alasql: alaSQLSpace.AlaSQL;
-export default alasql;


### PR DESCRIPTION
I had always fought with importing alasql in typescript... 
The solution I used - 
declare module "alasql";
in my own typings.d.ts files, and losing all of the types for it.

Because - 

previous exports didn't reflect what was actually exported from the library.

previously:
import alasql from "alasq";

gave typings, but alasql was undefined.

import * as alasql gave the correct imported value, but typscript threw error "import("[..]/node_modules/alasql/types/alasql")' has no call signatures"\

Now you can 
import * as alasql from "alasq";
or
import alasql = require("alasql")

and both give valid types AND is callable at runtime

This could be fixed - ir the actual js exports, which would be more dangerous, or just in typings. So I chose this route.
