### PR TITLE
fix(IndexedDB): Added fix when there is no keyPaths(columns) in indexDB

### DIFF
--- a/src/91indexeddb.js
+++ b/src/91indexeddb.js
@@ -339,7 +339,9 @@ IDB.fromTable = function (databaseid, tableid, cb, idx, query) {
 		cur.onsuccess = () => {
 			const cursor = cur.result;
 			if (cursor) {
-				res.push(cursor.value);
+				// if keyPath(columns) is not present then we take the key and value as object.
+				const cursorValue = typeof cursor === Object ? cursor.value : { [cursor.key]: cursor.value };
+				res.push(cursorValue);
 				cursor.continue();
 			} else {
 				ixdb.close();

--- a/test/test1556.js
+++ b/test/test1556.js
@@ -1,0 +1,42 @@
+if (typeof exports === 'object') {
+	var assert = require('assert');
+	var alasql = require('..');
+}
+
+// only run in browser
+if (typeof exports != 'object') {
+	describe('Test 1556 - indexeddb should return rowKey-value when no keyPath(columns) is present', () => {
+		const sql = alasql.promise;
+		before(() => {
+			// delete indexeddb
+			return sql('DROP IndexedDB DATABASE IF EXISTS alaindexed;');
+		});
+
+		it('should respond rowkey-value as the response', async () => {
+			await sql(
+				'CREATE INDEXEDDB DATABASE IF NOT EXISTS alaindexed;' +
+					'ATTACH INDEXEDDB DATABASE alaindexed;' +
+					'USE alaindexed'
+			);
+			await sql(['CREATE TABLE IF NOT EXISTS mytable1']);
+
+			await sql(["INSERT INTO mytable1 VALUES ( 'random_value' )"]);
+
+			// adding data to db using api/idbObject
+			const request = indexedDB.open('alaindexed');
+			request.onsuccess = () => {
+				var tx = request.result.transaction(['mytable1'], 'readwrite');
+				var tb = tx.objectStore('mytable1');
+				tb.add('random_value2', 'shell_id_key');
+			};
+
+			request.onerror = () => {
+				reject(new Error('IndexedDB insert error'));
+			};
+
+			const data = await sql('SELECT * from [mytable1]');
+			console.log('FInal data res ', data);
+			assert.deepEqual(data, [{1: ['random_value']}, {shell_id_key: 'random_value2'}]);
+		});
+	});
+}


### PR DESCRIPTION
I have added a fix for the issue: #1556 .
If the keyPath is not present in the value, then I'm creating a object with rowKey as key of the object and returning as ` {shell_id_key: 'random_value2'}` where `shell_id_key` is the rowKey. 

<img width="719" alt="Screenshot 2023-07-13 at 6 38 01 PM" src="https://github.com/AlaSQL/alasql/assets/19667550/a5058680-6e0f-4e19-bc14-4dc385d50f8f">



Thank you for the time you are putting into AlaSQL!


