### PR TITLE
Fix JSON file error handling

### DIFF
--- a/src/84from.js
+++ b/src/84from.js
@@ -153,22 +153,32 @@ alasql.from.JSON = function (filename, opts, cb, idx, query) {
 	//console.log('cb',cb);
 	//console.log('JSON');
 	filename = alasql.utils.autoExtFilename(filename, 'json', opts);
-	(alasql.utils.loadFile(filename, !!cb, function (data) {
-		//		console.log('DATA:'+data);
-		//		res = [{a:1}];
-		res = JSON.parse(data);
-		if (cb) {
-			res = cb(res, idx, query);
+	const errorHandler = err => {
+		const error = err instanceof Error ? err : new Error(err);
+		if (query && query.cb) {
+			query.cb(null, error);
+			return;
 		}
-	}),
-		err => {
-			const error = err instanceof Error ? err : new Error(err);
-			if (query && query.cb) {
-				query.cb(null, error);
+		throw error;
+	};
+	alasql.utils.loadFile(
+		filename,
+		!!cb,
+		function (data) {
+			//		console.log('DATA:'+data);
+			//		res = [{a:1}];
+			try {
+				res = JSON.parse(data);
+			} catch (error) {
+				errorHandler(error);
 				return;
 			}
-			throw error;
-		});
+			if (cb) {
+				res = cb(res, idx, query);
+			}
+		},
+		errorHandler
+	);
 	return res;
 };
 

--- a/test/test1314-invalid.txt
+++ b/test/test1314-invalid.txt
@@ -1,0 +1,1 @@
+invalid JSON

--- a/test/test1314.js
+++ b/test/test1314.js
@@ -1,0 +1,37 @@
+if (typeof exports === 'object') {
+	var assert = require('assert');
+	var alasql = require('..');
+} else {
+	__dirname = '.';
+}
+
+describe('Test 1314 - JSON file errors', function () {
+	it('1. Rejects when the JSON file does not exist', async function () {
+		await assert.rejects(
+			alasql(['SELECT * FROM JSON("' + __dirname + '/test1314-missing.json")']),
+			function (error) {
+				return error instanceof Error && error.code === 'ENOENT';
+			}
+		);
+	});
+
+	it('2. Passes missing file errors to the query callback', function (done) {
+		alasql(
+			'SELECT * FROM JSON("' + __dirname + '/test1314-missing.json")',
+			[],
+			function (result, error) {
+				assert.strictEqual(result, null);
+				assert(error instanceof Error);
+				assert.strictEqual(error.code, 'ENOENT');
+				done();
+			}
+		);
+	});
+
+	it('3. Rejects when the JSON file is invalid', async function () {
+		await assert.rejects(
+			alasql(['SELECT * FROM JSON("' + __dirname + '/test1314-invalid.txt")']),
+			SyntaxError
+		);
+	});
+});


### PR DESCRIPTION
Fixes #1314

## Summary

- pass JSON file-loading failures to the query error callback
- route malformed JSON parse failures through the same error path
- add regression coverage for callbacks and lazy promises

## Testing

- `bun test --preload ./test/bun-setup.js ./test/test1314.js` (3 passed)
- `bun run test-only` (2191 passed, 213 skipped, 0 failed)
- `bun x prettier --check src/84from.js test/test1314.js`