### PR TITLE
Fix UNION with nested SELECT

### DIFF
--- a/src/40select.js
+++ b/src/40select.js
@@ -593,6 +593,16 @@ yy.Select = class Select {
 			}
 			return nq;
 		});
+
+		// Subquery indices (queriesidx) are assigned against the statement-level
+		// queries list, so a subquery that references another subquery
+		// (e.g. a scalar subquery nested inside a subquery's WHERE clause)
+		// needs access to the same compiled list
+		query.queriesfn.forEach(function (nq) {
+			if (!nq.query.queriesfn) {
+				nq.query.queriesfn = query.queriesfn;
+			}
+		});
 	}
 };
 

--- a/src/420from.js
+++ b/src/420from.js
@@ -92,9 +92,18 @@ yy.Select.prototype.compileFrom = function (query) {
 			if (typeof source.subquery.query.modifier === 'undefined') {
 				source.subquery.query.modifier = 'RECORDSET';
 			}
-			source.columns = source.subquery.query.columns;
+			// If the subquery could not resolve all its columns at compile time
+			// (e.g. SELECT * over parameter data), its columns list is incomplete,
+			// so leave the columns unknown and let SELECT * expand from the data
+			source.columns = source.subquery.query.dirtyColumns ? [] : source.subquery.query.columns;
 
 			source.datafn = (query, params, cb, idx, alasql) => {
+				// Subqueries parsed inside this FROM subselect (e.g. a scalar
+				// subquery in its column list) are hoisted to the statement-level
+				// queries list, so share the compiled list with the subselect
+				if (!source.subquery.query.queriesfn && query.queriesfn) {
+					source.subquery.query.queriesfn = query.queriesfn;
+				}
 				let res;
 				source.subquery(query.params, data => {
 					res = data.data;

--- a/test/test1264.js
+++ b/test/test1264.js
@@ -1,0 +1,116 @@
+if (typeof exports === 'object') {
+	var assert = require('assert');
+	var alasql = require('..');
+}
+
+let testId = '1264';
+
+describe(`Test ${testId} - UNION with nested SELECT`, function () {
+	before(function () {
+		alasql('create database test' + testId);
+		alasql('use test' + testId);
+	});
+
+	after(function () {
+		alasql('drop database test' + testId);
+	});
+
+	var t1 = [
+		{id: '1', a: 'one'},
+		{id: '2', a: 'two'},
+		{id: '3', a: 'three'},
+		{id: '4', a: 'four'},
+	];
+	var t2 = [
+		{id: '1', b: 'A'},
+		{id: '2', b: 'B'},
+		{id: '5', b: 'E'},
+		{id: '6', b: 'F'},
+	];
+
+	var expected = [
+		{id: '1', b: 'A'},
+		{id: '2', b: 'B'},
+		{id: '5', b: 'E'},
+		{id: '6', b: 'F'},
+		{id: '1', a: 'one', c: 4},
+		{id: '2', a: 'two', c: 4},
+		{id: '3', a: 'three', c: 4},
+		{id: '4', a: 'four', c: 4},
+	];
+
+	it('A) UNION CORRESPONDING with a scalar subquery column', function () {
+		var res = alasql(
+			'SELECT *, (SELECT COUNT(*) FROM ?) AS c FROM ? T1 UNION CORRESPONDING SELECT * FROM ?',
+			[t1, t1, t2]
+		);
+		assert.deepEqual(res, expected);
+	});
+
+	it('B) UNION CORRESPONDING with a scalar subquery column, nested in FROM', function () {
+		var res = alasql(
+			'SELECT * FROM (SELECT *, (SELECT COUNT(*) FROM ?) AS c FROM ? T1 UNION CORRESPONDING SELECT * FROM ?)',
+			[t1, t1, t2]
+		);
+		assert.deepEqual(res, expected);
+	});
+
+	it('C) UNION ALL CORRESPONDING with a scalar subquery column, nested in FROM', function () {
+		var res = alasql(
+			'SELECT * FROM (SELECT *, (SELECT COUNT(*) FROM ?) AS c FROM ? T1 UNION ALL CORRESPONDING SELECT * FROM ?)',
+			[t1, t1, t2]
+		);
+		assert.deepEqual(res, [
+			{id: '1', a: 'one', c: 4},
+			{id: '2', a: 'two', c: 4},
+			{id: '3', a: 'three', c: 4},
+			{id: '4', a: 'four', c: 4},
+			{id: '1', b: 'A'},
+			{id: '2', b: 'B'},
+			{id: '5', b: 'E'},
+			{id: '6', b: 'F'},
+		]);
+	});
+
+	it('D) scalar subquery column on the right side of the UNION', function () {
+		var res = alasql(
+			'SELECT * FROM (SELECT * FROM ? UNION CORRESPONDING SELECT *, (SELECT COUNT(*) FROM ?) AS c FROM ?)',
+			[t2, t1, t1]
+		);
+		assert.deepEqual(res, [
+			{id: '1', a: 'one', c: 4},
+			{id: '2', a: 'two', c: 4},
+			{id: '3', a: 'three', c: 4},
+			{id: '4', a: 'four', c: 4},
+			{id: '1', b: 'A'},
+			{id: '2', b: 'B'},
+			{id: '5', b: 'E'},
+			{id: '6', b: 'F'},
+		]);
+	});
+
+	it('E) scalar subquery column in a FROM subselect without UNION', function () {
+		var res = alasql('SELECT * FROM (SELECT *, (SELECT COUNT(*) FROM ?) AS c FROM ?)', [t1, t1]);
+		assert.deepEqual(res, [
+			{id: '1', a: 'one', c: 4},
+			{id: '2', a: 'two', c: 4},
+			{id: '3', a: 'three', c: 4},
+			{id: '4', a: 'four', c: 4},
+		]);
+	});
+
+	it('F) scalar subquery nested inside another scalar subquery', function () {
+		var data = [
+			{TYPE: 'CAUSE', PARENT: 'FL1', FAILURECODE: '999', FAILURELIST: 'FLX'},
+			{TYPE: 'PROBLEM', PARENT: 'FL0', FAILURECODE: '123', FAILURELIST: 'FL1'},
+			{TYPE: '', PARENT: '', FAILURECODE: '234', FAILURELIST: 'FL0'},
+		];
+		var res = alasql(
+			"SELECT * FROM ? WHERE TYPE = 'CAUSE' AND PARENT = " +
+				"(SELECT FAILURELIST FROM ? WHERE FAILURECODE = '123' AND TYPE = 'PROBLEM' AND PARENT = " +
+				"(SELECT FAILURELIST FROM ? WHERE FAILURECODE = '234' AND TYPE = '' AND PARENT = ''))",
+			[data, data, data]
+		);
+		assert.deepEqual(res, [{TYPE: 'CAUSE', PARENT: 'FL1', FAILURECODE: '999', FAILURELIST: 'FLX'}]);
+	});
+});


### PR DESCRIPTION
Fixes #1264

## Summary

Queries like `SELECT * FROM (SELECT *, (SELECT COUNT(*) FROM ?) AS c FROM ? UNION CORRESPONDING SELECT * FROM ?)` crashed with `Cannot read property '0' of undefined`, as did scalar subqueries nested inside another subquery's WHERE clause.

The parser hoists every parenthesized scalar subquery into a single statement-level `queries` list, and the compiled expressions reference `this.queriesfn[queriesidx - 1]` on their own query object — but only the outermost query ever received the compiled list, so any subquery reference evaluated inside a FROM subselect or inside another subquery found `this.queriesfn` undefined.

- share the compiled statement-level `queriesfn` list with nested compiled queries in `compileQueries` and with FROM subselects, so `queriesidx` references resolve at any nesting depth
- treat a FROM subselect's column list as unknown when it was compiled with `dirtyColumns` (e.g. `SELECT *` over parameter data), so the outer `SELECT *` expands from the data instead of projecting only the statically known columns
- add regression coverage for the queries from the issue

## Testing

- `bun test --preload ./test/bun-setup.js ./test/test1264.js` (6 passed)
- `bun run test-only` (2194 passed, 213 skipped, 0 failed)
- `bun x prettier --check src/40select.js src/420from.js test/test1264.js`