### PR TITLE
Fix SUBSTRING with a non-positive start position

### DIFF
--- a/src/15utility.js
+++ b/src/15utility.js
@@ -935,6 +935,18 @@ var arrayIntersectDeep = (utils.arrayIntersectDeep = function (a, b) {
 });
 
 /**
+  SUBSTRING with MySQL semantics for a non-positive start: a start of 0 returns
+  '', a negative start counts from the end of the string, and a start that
+  reaches before the string start returns ''. `len` is optional.
+  */
+var substr = (utils.substr = function substr(str, start, len) {
+	if (start == 0) return '';
+	var from = start < 0 ? str.length + start : start - 1;
+	if (from < 0) return '';
+	return len === undefined ? str.substr(from) : str.substr(from, len);
+});
+
+/**
   Deep clone objects
   */
 var cloneDeep = (utils.cloneDeep = function cloneDeep(obj) {

--- a/src/55functions.js
+++ b/src/55functions.js
@@ -186,24 +186,8 @@ stdlib.SUBSTRING =
 	stdlib.SUBSTR =
 	stdlib.MID =
 		function (a, b, c) {
-			if (arguments.length == 2)
-				return und(
-					a,
-					'(__alasql_tmp=(' +
-						b +
-						'),__alasql_tmp==0?"":(__alasql_tmp<0?(y.length+__alasql_tmp<0?"":y.substr(y.length+__alasql_tmp)):y.substr(__alasql_tmp-1)))'
-				);
-			else if (arguments.length == 3)
-				return und(
-					a,
-					'(__alasql_tmp=(' +
-						b +
-						'),__alasql_tmp==0?"":(__alasql_tmp<0?(y.length+__alasql_tmp<0?"":y.substr(y.length+__alasql_tmp,' +
-						c +
-						')):y.substr(__alasql_tmp-1,' +
-						c +
-						')))'
-				);
+			if (arguments.length == 2) return und(a, 'alasql.utils.substr(y,' + b + ')');
+			else if (arguments.length == 3) return und(a, 'alasql.utils.substr(y,' + b + ',' + c + ')');
 		};
 
 stdfn.REGEXP_LIKE = function (a, b, c) {

--- a/src/55functions.js
+++ b/src/55functions.js
@@ -186,8 +186,24 @@ stdlib.SUBSTRING =
 	stdlib.SUBSTR =
 	stdlib.MID =
 		function (a, b, c) {
-			if (arguments.length == 2) return und(a, 'y.substr(' + b + '-1)');
-			else if (arguments.length == 3) return und(a, 'y.substr(' + b + '-1,' + c + ')');
+			if (arguments.length == 2)
+				return und(
+					a,
+					'(__alasql_tmp=(' +
+						b +
+						'),__alasql_tmp==0?"":(__alasql_tmp<0?(y.length+__alasql_tmp<0?"":y.substr(y.length+__alasql_tmp)):y.substr(__alasql_tmp-1)))'
+				);
+			else if (arguments.length == 3)
+				return und(
+					a,
+					'(__alasql_tmp=(' +
+						b +
+						'),__alasql_tmp==0?"":(__alasql_tmp<0?(y.length+__alasql_tmp<0?"":y.substr(y.length+__alasql_tmp,' +
+						c +
+						')):y.substr(__alasql_tmp-1,' +
+						c +
+						')))'
+				);
 		};
 
 stdfn.REGEXP_LIKE = function (a, b, c) {

--- a/test/test-substring-negative-start.js
+++ b/test/test-substring-negative-start.js
@@ -1,0 +1,35 @@
+if (typeof exports === 'object') {
+	var assert = require('assert');
+	var alasql = require('..');
+}
+
+describe('SUBSTRING with non-positive start position', function () {
+	it('follows MySQL semantics for start = 0', function () {
+		assert.strictEqual(alasql("SELECT VALUE SUBSTRING('abcdef', 0, 3)"), '');
+		assert.strictEqual(alasql("SELECT VALUE SUBSTRING('abcdef', 0)"), '');
+	});
+
+	it('follows MySQL semantics for a negative start (counts from the end)', function () {
+		assert.strictEqual(alasql("SELECT VALUE SUBSTRING('abcdef', -1, 3)"), 'f');
+		assert.strictEqual(alasql("SELECT VALUE SUBSTRING('abcdef', -2, 3)"), 'ef');
+		assert.strictEqual(alasql("SELECT VALUE SUBSTRING('abcdef', -2)"), 'ef');
+		assert.strictEqual(alasql("SELECT VALUE SUBSTRING('abcdef', -6)"), 'abcdef');
+	});
+
+	it('returns empty when a negative start reaches past the string start', function () {
+		assert.strictEqual(alasql("SELECT VALUE SUBSTRING('abcdef', -7, 3)"), '');
+		assert.strictEqual(alasql("SELECT VALUE SUBSTRING('abcdef', -10, 3)"), '');
+		assert.strictEqual(alasql("SELECT VALUE SUBSTRING('abcdef', -7)"), '');
+	});
+
+	it('leaves positive start positions unchanged', function () {
+		assert.strictEqual(alasql("SELECT VALUE SUBSTRING('abcdef', 1, 3)"), 'abc');
+		assert.strictEqual(alasql("SELECT VALUE SUBSTRING('abcdef', 2, 3)"), 'bcd');
+		assert.strictEqual(alasql("SELECT VALUE SUBSTRING('abcdef', 4)"), 'def');
+	});
+
+	it('applies the same rules to the SUBSTR and MID aliases', function () {
+		assert.strictEqual(alasql("SELECT VALUE SUBSTR('abcdef', 0, 3)"), '');
+		assert.strictEqual(alasql("SELECT VALUE MID('abcdef', -2, 3)"), 'ef');
+	});
+});


### PR DESCRIPTION
## Problem

`SUBSTRING` / `SUBSTR` / `MID` compile `SUBSTRING(str, pos, len)` to `str.substr(pos - 1, len)`. When `pos` is `0` or negative, `pos - 1` becomes a negative index, and JavaScript's `String.prototype.substr()` counts a negative start from the **end** of the string. The result is neither correct nor consistent with any SQL dialect:

```js
alasql("SELECT VALUE SUBSTRING('abcdef', 0, 3)")   // 'f'   (MySQL: '')
alasql("SELECT VALUE SUBSTRING('abcdef', -1, 3)")  // 'ef'  (MySQL: 'f')
alasql("SELECT VALUE SUBSTRING('abcdef', -2, 3)")  // 'def' (MySQL: 'ef')
```

So a computed start position that lands on `0` or goes negative silently returns wrong characters.

## Fix

Follow MySQL semantics (verified against MySQL 8), which alasql already matches for positive positions:

- start `= 0` yields an empty string;
- a negative start counts from the end (`SUBSTRING('abcdef', -2)` -> `'ef'`), clamped to an empty string when it reaches past the beginning (`SUBSTRING('abcdef', -7)` -> `''`);
- positive start positions are unchanged.

| call | before | after (= MySQL 8) |
| --- | --- | --- |
| `SUBSTRING('abcdef', 0, 3)` | `'f'` | `''` |
| `SUBSTRING('abcdef', -1, 3)` | `'ef'` | `'f'` |
| `SUBSTRING('abcdef', -2, 3)` | `'def'` | `'ef'` |
| `SUBSTRING('abcdef', -2)` | `'def'` | `'ef'` |
| `SUBSTRING('abcdef', -7, 3)` | `'bcd'` | `''` |
| `SUBSTRING('abcdef', 2, 3)` | `'bcd'` | `'bcd'` |

## Test

Added `test/test-substring-negative-start.js`. `yarn test` passes (2193 tests).
