### PR TITLE
Fix typos in README and CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # How to Contribute to AlaSQL
 
-Thank you very much for your interest! AlaSQL has a lot of thing to be improved, and your help is very appreciated! 
+Thank you very much for your interest! AlaSQL has a lot of things to be improved, and your help is very appreciated! 
 
 For you to submit a pull request: 
 
@@ -15,7 +15,7 @@ For you to submit a pull request:
 - Run `yarn test` to verify only the new test fails
 - Implement your contributions in `src/`
 - Run `yarn test` and verify all tests are OK
-- Format the souce with `yarn format`
+- Format the source with `yarn format`
 - Commit changes to git and push to your forked repo
 - Click "Create Pull-request" when looking at your forked repo on Github
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 # AlaSQL
 
-<h2 align="center"><a href="http://alasql.org"><img src="https://cloud.githubusercontent.com/assets/1063454/19309516/94f8007e-9085-11e6-810f-62fd60b42185.png" alt="AlaSQL logo" styl="max-width:80%"/></a>
+<h2 align="center"><a href="http://alasql.org"><img src="https://cloud.githubusercontent.com/assets/1063454/19309516/94f8007e-9085-11e6-810f-62fd60b42185.png" alt="AlaSQL logo" style="max-width:80%"/></a>
 </h2>
 
 AlaSQL - _( [à la](http://en.wiktionary.org/wiki/%C3%A0_la) [SQL](http://en.wikipedia.org/wiki/SQL) ) [ælæ ɛskju:ɛl]_ - is an open source SQL database for JavaScript with a strong focus on query speed and data source flexibility for both relational data and schemaless data. It works in the web browser, Node.js, and mobile apps.


### PR DESCRIPTION
## Summary
- `README.md`: fix invalid `styl` attribute to `style` on the logo `<img>` tag (the typo meant the `max-width:80%` style was silently ignored by browsers)
- `CONTRIBUTING.md`: fix "a lot of thing" -> "a lot of things"
- `CONTRIBUTING.md`: fix "souce" -> "source"

Small documentation-only fixes, no functional/code changes.
